### PR TITLE
docs: add Autohand Code setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# OK Skills: AI Coding Agent Skills for Codex, Claude Code, Cursor, OpenClaw, and More
+# OK Skills: AI Coding Agent Skills for Codex, Claude Code, Cursor, OpenClaw, Autohand Code, and More
 
 English | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Tiếng Việt](README.vi.md) | [Русский](README.ru.md) | [हिन्दी](README.hi.md)
 
 [![Mentioned in Awesome Codex CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/RoggeOhta/awesome-codex-cli)
 
-Curated AI coding agent skills and `CLAUDE.md` / `AGENTS.md` playbooks for Codex, Claude Code, Cursor, OpenClaw, Trae, and other `SKILL.md`-compatible tools.
+Curated AI coding agent skills and `CLAUDE.md` / `AGENTS.md` playbooks for Codex, Claude Code, Cursor, OpenClaw, Autohand Code, Trae, and other `SKILL.md`-compatible tools.
 
 This repo currently bundles **34 reusable skills**, all maintained as top-level skill directories in this repo. Clone it into `~/.agents/skills/ok-skills`; the directories inside already match the layout expected by `AGENTS.md`-driven workflows, and [`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) provides a Claude Code-oriented agent playbook.
 
@@ -14,7 +14,7 @@ If you are looking for **Codex skills**, **Claude Code skills**, **Cursor skills
 
 ## Who This Repo Is For
 
-- You use Codex, Claude Code, Cursor, OpenClaw, Trae, or another AI coding agent and want reusable skills instead of ad-hoc prompts.
+- You use Codex, Claude Code, Cursor, OpenClaw, Autohand Code, Trae, or another AI coding agent and want reusable skills instead of ad-hoc prompts.
 - You maintain `CLAUDE.md` / `AGENTS.md` / `SKILL.md` workflows and want portable instructions that work across projects.
 - You need battle-tested skills for docs lookup, browser automation, planning, prompt engineering, frontend design, PDFs, Office documents, slide decks, and spreadsheets.
 
@@ -32,6 +32,18 @@ If you only install a few skills first, start with these:
 mkdir -p ~/.agents/skills
 cd ~/.agents/skills
 git clone https://github.com/mxyhi/ok-skills.git ok-skills
+```
+
+For Autohand Code, clone the repo into either the user-level or project-level skills directory:
+
+```bash
+# User-level skills
+mkdir -p ~/.autohand/skills
+git clone https://github.com/mxyhi/ok-skills.git ~/.autohand/skills/ok-skills
+
+# Project-level skills
+mkdir -p .autohand/skills
+git clone https://github.com/mxyhi/ok-skills.git .autohand/skills/ok-skills
 ```
 
 After cloning, the repo lives at `~/.agents/skills/ok-skills`, and the directories inside already follow the expected layout:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,10 +1,10 @@
-# OK Skills：面向 Codex、Claude Code、Cursor、OpenClaw 等工具的 AI Agent Skills 集合
+# OK Skills：面向 Codex、Claude Code、Cursor、OpenClaw、Autohand Code 等工具的 AI Agent Skills 集合
 
 [English](README.md) | 简体中文 | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Tiếng Việt](README.vi.md) | [Русский](README.ru.md) | [हिन्दी](README.hi.md)
 
 [![Mentioned in Awesome Codex CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/RoggeOhta/awesome-codex-cli)
 
-这是一个面向 Codex、Claude Code、Cursor、OpenClaw、Trae 以及其他兼容 `SKILL.md` / `CLAUDE.md` / `AGENTS.md` 工作流工具的技能仓库。
+这是一个面向 Codex、Claude Code、Cursor、OpenClaw、Autohand Code、Trae 以及其他兼容 `SKILL.md` / `CLAUDE.md` / `AGENTS.md` 工作流工具的技能仓库。
 
 当前仓库共收录 **34 个可复用技能**，全部作为顶层技能目录由本仓直接维护。把它 clone 到 `~/.agents/skills/ok-skills` 即可，仓库内部目录已经符合 `AGENTS.md` 所需的 skills 规范，[`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) 则提供面向 Claude Code 的 agent playbook。
 
@@ -14,7 +14,7 @@
 
 ## 适合谁
 
-- 你在用 Codex、Claude Code、Cursor、OpenClaw、Trae 或其他 AI coding agent，希望复用技能而不是每次临时写 prompt。
+- 你在用 Codex、Claude Code、Cursor、OpenClaw、Autohand Code、Trae 或其他 AI coding agent，希望复用技能而不是每次临时写 prompt。
 - 你在维护 `CLAUDE.md` / `AGENTS.md` / `SKILL.md` 体系，希望不同项目之间可以迁移同一套工作流。
 - 你需要现成的文档查询、浏览器自动化、规划、提示工程、前端设计、PDF、Office 文档、演示文稿和表格类技能。
 
@@ -32,6 +32,18 @@
 mkdir -p ~/.agents/skills
 cd ~/.agents/skills
 git clone https://github.com/mxyhi/ok-skills.git ok-skills
+```
+
+如果使用 Autohand Code，可以把仓库 clone 到用户级或项目级 skills 目录：
+
+```bash
+# 用户级 skills
+mkdir -p ~/.autohand/skills
+git clone https://github.com/mxyhi/ok-skills.git ~/.autohand/skills/ok-skills
+
+# 项目级 skills
+mkdir -p .autohand/skills
+git clone https://github.com/mxyhi/ok-skills.git .autohand/skills/ok-skills
 ```
 
 clone 后仓库位于 `~/.agents/skills/ok-skills`，其内部目录已经符合预期布局：


### PR DESCRIPTION
## Summary
- list Autohand Code alongside the existing SKILL.md-compatible coding agents
- add user-level and project-level Autohand Code clone paths in the quick start
- mirror the public-facing quick start update in README.zh-CN.md

## Validation
- git diff --check

This keeps the change documentation-only and follows the repo's existing clone-based install style.