### PR TITLE
Add Ontoly Software Graph skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ English | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [�
 
 Curated AI coding agent skills and `CLAUDE.md` / `AGENTS.md` playbooks for Codex, Claude Code, Cursor, OpenClaw, Autohand Code, Trae, and other `SKILL.md`-compatible tools.
 
-This repo currently bundles **31 reusable skills**, all maintained as top-level skill directories in this repo. Clone it into `~/.agents/skills/ok-skills`; the directories inside already match the layout expected by `AGENTS.md`-driven workflows, and [`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) provides a Claude Code-oriented agent playbook.
+This repo currently bundles **32 reusable skills**, all maintained as top-level skill directories in this repo. Clone it into `~/.agents/skills/ok-skills`; the directories inside already match the layout expected by `AGENTS.md`-driven workflows, and [`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) provides a Claude Code-oriented agent playbook.
 
 If you are looking for **Codex skills**, **Claude Code skills**, **Cursor skills**, **OpenClaw skills**, reusable **CLAUDE.md / AGENTS.md** playbooks, or practical **SKILL.md** examples, this repository is designed to be both searchable and immediately usable.
 
-**Popular use cases:** docs lookup, browser automation, prompt engineering, planning workflows, frontend design, PDF/Word/PPTX/XLSX authoring.
+**Popular use cases:** docs lookup, browser automation, prompt engineering, planning workflows, codebase understanding, frontend design, PDF/Word/PPTX/XLSX authoring.
 
 ## Who This Repo Is For
 
@@ -98,6 +98,7 @@ Then ask naturally:
 - [domain-modeling](domain-modeling/SKILL.md): build and sharpen project domain terminology, `CONTEXT.md`, and ADRs.
 - [codebase-design](codebase-design/SKILL.md): shared deep-module vocabulary for seams, interfaces, leverage, locality, and testability.
 - [improve-codebase-architecture](improve-codebase-architecture/SKILL.md): find deepening opportunities that improve locality, leverage, testability, and AI navigation.
+- [ontoly-software-graph](ontoly-software-graph/SKILL.md): use Ontoly's deterministic Software Graph and MCP capabilities for architecture review, request tracing, dependency analysis, configuration lookup, and impact analysis.
 - [prototype](prototype/SKILL.md): build throwaway logic or UI prototypes to answer design questions quickly.
 - [karpathy-guidelines](karpathy-guidelines/SKILL.md): behavioral coding guidelines that reduce overcomplication, hidden assumptions, and unverifiable changes.
 - [migrate-to-shoehorn](migrate-to-shoehorn/SKILL.md): migrate test `as` assertions to `@total-typescript/shoehorn`.
@@ -165,6 +166,7 @@ Then ask naturally:
 | [domain-modeling](domain-modeling/SKILL.md)                   | Build and sharpen project domain terminology, `CONTEXT.md`, and ADRs.                                                                                         | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/domain-modeling)                          |
 | [codebase-design](codebase-design/SKILL.md)                   | Shared deep-module vocabulary for seams, interfaces, leverage, locality, and testability.                                                                                         | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/codebase-design)                          |
 | [improve-codebase-architecture](improve-codebase-architecture/SKILL.md) | Find deepening opportunities that improve locality, leverage, testability, and AI navigation.                                                                                           | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture)                              |
+| [ontoly-software-graph](ontoly-software-graph/SKILL.md)         | Use Ontoly's deterministic Software Graph and MCP capabilities for architecture review, request tracing, dependency analysis, configuration lookup, and impact analysis.              | [0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly/tree/main/skills)                                                      |
 | [prototype](prototype/SKILL.md) | Build throwaway logic or UI prototypes to answer design questions quickly. | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/prototype) |
 | [karpathy-guidelines](karpathy-guidelines/SKILL.md)                 | Behavioral coding guidelines that reduce overcomplication, hidden assumptions, and unverifiable changes.                                                                                                           | [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines)               |
 | [migrate-to-shoehorn](migrate-to-shoehorn/SKILL.md)                 | Migrate test files from `as` type assertions to `@total-typescript/shoehorn`.                                                                                                           | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/misc/migrate-to-shoehorn)                                        |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,11 +6,11 @@
 
 这是一个面向 Codex、Claude Code、Cursor、OpenClaw、Autohand Code、Trae 以及其他兼容 `SKILL.md` / `CLAUDE.md` / `AGENTS.md` 工作流工具的技能仓库。
 
-当前仓库共收录 **31 个可复用技能**，全部作为顶层技能目录由本仓直接维护。把它 clone 到 `~/.agents/skills/ok-skills` 即可，仓库内部目录已经符合 `AGENTS.md` 所需的 skills 规范，[`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) 则提供面向 Claude Code 的 agent playbook。
+当前仓库共收录 **32 个可复用技能**，全部作为顶层技能目录由本仓直接维护。把它 clone 到 `~/.agents/skills/ok-skills` 即可，仓库内部目录已经符合 `AGENTS.md` 所需的 skills 规范，[`CLAUDE_AGENTS.md`](CLAUDE_AGENTS.md) 则提供面向 Claude Code 的 agent playbook。
 
 如果你在找 **Codex skills**、**Claude Code skills**、**Cursor skills**、**OpenClaw skills**、可复用的 **CLAUDE.md / AGENTS.md** 模板，或者一套能直接落地的 **SKILL.md** 示例仓库，这个项目就是为搜索可发现性和开箱即用而整理的。
 
-**高频使用场景：** 最新文档查询、浏览器自动化、提示工程、复杂任务规划、前端设计，以及 PDF / Word / PPTX / XLSX 内容处理。
+**高频使用场景：** 最新文档查询、浏览器自动化、提示工程、复杂任务规划、代码库理解、前端设计，以及 PDF / Word / PPTX / XLSX 内容处理。
 
 ## 适合谁
 
@@ -98,6 +98,7 @@ Claude Code 或 Codex 的全局指令可以从 [`CLAUDE_AGENTS.md`](CLAUDE_AGENT
 - [domain-modeling](domain-modeling/SKILL.md): build and sharpen project domain terminology, `CONTEXT.md`, and ADRs.
 - [codebase-design](codebase-design/SKILL.md): shared deep-module vocabulary for seams, interfaces, leverage, locality, and testability.
 - [improve-codebase-architecture](improve-codebase-architecture/SKILL.md)：发现能提升 locality、leverage、可测试性和 AI 可导航性的架构 deepening 机会。
+- [ontoly-software-graph](ontoly-software-graph/SKILL.md)：使用 Ontoly 的确定性 Software Graph 和 MCP 能力进行架构审查、请求追踪、依赖分析、配置查询与影响分析。
 - [prototype](prototype/SKILL.md): 构建一次性逻辑或 UI 原型，快速回答设计问题。
 - [karpathy-guidelines](karpathy-guidelines/SKILL.md)：减少过度复杂、隐藏假设和不可验证改动的编码行为准则。
 - [migrate-to-shoehorn](migrate-to-shoehorn/SKILL.md)：把测试里的 `as` 类型断言迁移到 `@total-typescript/shoehorn`。
@@ -164,6 +165,7 @@ Claude Code 或 Codex 的全局指令可以从 [`CLAUDE_AGENTS.md`](CLAUDE_AGENT
 | [domain-modeling](domain-modeling/SKILL.md)                   | Build and sharpen project domain terminology, `CONTEXT.md`, and ADRs.                                                                                         | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/domain-modeling)                          |
 | [codebase-design](codebase-design/SKILL.md)                   | Shared deep-module vocabulary for seams, interfaces, leverage, locality, and testability.                                                                                         | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/codebase-design)                          |
 | [improve-codebase-architecture](improve-codebase-architecture/SKILL.md) | 发现能提升 locality、leverage、可测试性和 AI 可导航性的架构 deepening 机会。                                                                   | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture)                              |
+| [ontoly-software-graph](ontoly-software-graph/SKILL.md)         | 使用 Ontoly 的确定性 Software Graph 和 MCP 能力进行架构审查、请求追踪、依赖分析、配置查询与影响分析。                                         | [0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly/tree/main/skills)                                                      |
 | [prototype](prototype/SKILL.md) | 构建一次性逻辑或 UI 原型，快速回答设计问题。 | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/prototype) |
 | [karpathy-guidelines](karpathy-guidelines/SKILL.md)                 | 减少过度复杂、隐藏假设和不可验证改动的编码行为准则。                                                                                                           | [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines)               |
 | [migrate-to-shoehorn](migrate-to-shoehorn/SKILL.md)                 | 把测试文件中的 `as` 类型断言迁移到 `@total-typescript/shoehorn`。                                                                              | [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/misc/migrate-to-shoehorn)                                        |

--- a/ontoly-software-graph/SKILL.md
+++ b/ontoly-software-graph/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: ontoly-software-graph
+description: Use Ontoly's deterministic Software Graph and MCP capabilities for repository architecture, request tracing, dependency analysis, configuration lookup, and impact analysis before falling back to source search.
+---
+
+# Ontoly Software Graph
+
+Use this skill when a coding agent needs graph-backed understanding of a TypeScript repository. Ontoly is the source of truth; the skill only teaches the workflow.
+
+## When to Use
+
+- Explain repository architecture or package/module topology
+- Trace a route, controller, service, function, or dependency path
+- Find services, controllers, providers, modules, routes, configuration, or environment variables
+- Estimate impact before refactoring or deleting code
+- Audit unresolved imports, circular dependencies, dead code, semantic coverage, or graph quality
+- Produce onboarding, documentation, or architecture-review notes with deterministic evidence
+
+## Workflow
+
+1. Check whether an Ontoly graph already exists: `.ontoly/`, `SoftwareGraph.json`, `diagnostics.json`, validation reports, graph hash, or MCP setup.
+2. If the graph is missing and local analysis is allowed, run:
+
+   ```bash
+   ontoly build .
+   ```
+
+3. Inspect graph health before answering: diagnostics, graph hash, semantic coverage, trust or quality score, framework detection, and build timestamp.
+4. Prefer Ontoly CLI or MCP capabilities over repository search for graph-answerable questions.
+5. Search source files only when Ontoly cannot answer, the graph is stale or incomplete, or the user explicitly asks for file-level verification.
+6. Always cite graph evidence: node IDs, edge types, file paths, source locations, diagnostics, framework analyzer output, and confidence.
+
+## Capability Map
+
+- Architecture review: `ExplainArchitecture`
+- Dependency analysis: `FindDependencies`
+- Impact analysis: `ImpactAnalysis`
+- Request tracing: `TraceExecution`
+- Configuration analysis: `FindConfigurationUsage`
+- Framework analysis: `FrameworkReport`
+- Dead-code review: `FindDeadCode`
+
+## Response Pattern
+
+Return the direct answer first, then evidence:
+
+```text
+AuthController handles authentication.
+
+Evidence:
+- node: class:src/auth/auth.controller.ts:AuthController
+- route edges: HANDLES POST /login and POST /logout
+- dependency edges: USES AuthService and JwtService
+
+Confidence: high, because the graph has controller, route, and dependency edges with source locations.
+```
+
+## Fallbacks
+
+- If the graph is missing, build it first when allowed.
+- If validation fails, report the graph issue and verify only the affected area with source search.
+- If several nodes match, show candidates with package/module context.
+- If nothing matches, return `NOT_FOUND` with the closest graph evidence instead of inventing an answer.
+


### PR DESCRIPTION
## Summary\n- adds a top-level Ontoly Software Graph skill\n- documents graph-first architecture, request tracing, dependency analysis, configuration lookup, and impact-analysis workflow\n- updates English and Simplified Chinese skill indexes\n\n## Validation\n- git diff --check